### PR TITLE
Srt in shaka

### DIFF
--- a/src/replay/components/player/VideoStreamer/ShakaVideoStreamer/shakaSetup.test.js
+++ b/src/replay/components/player/VideoStreamer/ShakaVideoStreamer/shakaSetup.test.js
@@ -27,7 +27,7 @@ describe('Shaka shakaSetup() polyfill installation.', () => {
   });
   test('MediaCapabilities installed by default when not configured', () => {
     const videoElement = {};
-    shakaSetup(shaka, videoElement, { shakaPlayer: { } });
+    shakaSetup(shaka, videoElement, { shakaPlayer: {} });
     expect(shaka.polyfill.installAll).not.toHaveBeenCalled();
     expect(shaka.polyfill.MediaCapabilities.install).toHaveBeenCalled();
   });

--- a/src/replay/components/player/VideoStreamer/ShakaVideoStreamer/shakaTextTrackManager.js
+++ b/src/replay/components/player/VideoStreamer/ShakaVideoStreamer/shakaTextTrackManager.js
@@ -41,7 +41,7 @@ function createSelectableTrack(
   };
 }
 
-const supportedContentTypes = ['text/vtt', 'application/ttml+xml'];
+const supportedContentTypes = ['text/vtt', 'application/ttml+xml', 'text/srt'];
 
 function isContentTypeSupported(sourceTrack) {
   const contentType = sourceTrack.contentType;
@@ -210,8 +210,7 @@ function getShakaTextTrackManager(
           contentType = contentType && contentType.substr(0, charsetPos);
         }
         return {
-          addPromise: Promise.resolve(
-            shakaPlayer.addTextTrack(
+          addPromise: shakaPlayer.addTextTrackAsync(
               sourceTrack.src,
               sourceTrack.language,
               sourceTrack.kind,
@@ -219,7 +218,7 @@ function getShakaTextTrackManager(
               null,
               sourceTrack.label
             )
-          ),
+          ,
           sourceTrack: sourceTrack
         };
       })

--- a/src/replay/components/player/VideoStreamer/ShakaVideoStreamer/shakaTextTrackManager.js
+++ b/src/replay/components/player/VideoStreamer/ShakaVideoStreamer/shakaTextTrackManager.js
@@ -211,14 +211,13 @@ function getShakaTextTrackManager(
         }
         return {
           addPromise: shakaPlayer.addTextTrackAsync(
-              sourceTrack.src,
-              sourceTrack.language,
-              sourceTrack.kind,
-              contentType,
-              null,
-              sourceTrack.label
-            )
-          ,
+            sourceTrack.src,
+            sourceTrack.language,
+            sourceTrack.kind,
+            contentType,
+            null,
+            sourceTrack.label
+          ),
           sourceTrack: sourceTrack
         };
       })

--- a/src/replay/components/player/VideoStreamer/ShakaVideoStreamer/types.js
+++ b/src/replay/components/player/VideoStreamer/ShakaVideoStreamer/types.js
@@ -55,6 +55,14 @@ export type ShakaPlayer = {
     codec?: ?string,
     label?: string
   ) => Promise<ShakaTrack>,
+  addTextTrackAsync: (
+    uri: string,
+    language: ?string,
+    kind: ?string,
+    mime: ?string,
+    codec?: ?string,
+    label?: string
+  ) => Promise<ShakaTrack>,
   cancelTrickPlay: () => void,
   configure: any => void,
   destroy: () => Promise<void>,


### PR DESCRIPTION
## *What* does this PR do?

1: Add SRT to supported content types now that it is supported in shaka since version 3.1
https://github.com/google/shaka-player/releases/tag/v3.1.0

Also updated to using addTextTrackAsync instead of addTextTrack.

## *Why* are you suggesting this change?

To support SRT subtitles