### PR TITLE
Add try/catch around shaka text track in blacklistExistingSideLoadedTracks

### DIFF
--- a/src/replay/components/player/VideoStreamer/ShakaVideoStreamer/shakaTextTrackManager.js
+++ b/src/replay/components/player/VideoStreamer/ShakaVideoStreamer/shakaTextTrackManager.js
@@ -274,25 +274,31 @@ function getShakaTextTrackManager(
   }
 
   function blacklistExistingSideLoadedTracks() {
-    const selectedTrack = shakaPlayer.isTextTrackVisible() ? getActiveShakaTrack() : null;
-    managedTextTracks
-      .filter(managedTrack => {
-        return managedTrack.sourceTrack != null;
-      })
-      .forEach(managedTrack => {
-        if (managedTrack.selectableTrack) {
-          managedTrack.selectableTrack = null;
-        }
-        if (
-          selectedTrack &&
-          managedTrack.shakaTrack &&
-          managedTrack.shakaTrack.active &&
-          isShakaTrackEqual(selectedTrack, managedTrack.shakaTrack)
-        ) {
-          shakaPlayer.setTextTrackVisibility(false);
-        }
-        managedTrack.isBlacklisted = true;
-      });
+    let selectedTrack = null;
+    try {
+      // In case of errors, this might fail due to early cleanup.
+      selectedTrack = shakaPlayer.isTextTrackVisible() ? getActiveShakaTrack() : null;
+    } catch (e) {}
+    if (selectedTrack) {
+      managedTextTracks
+        .filter(managedTrack => {
+          return managedTrack.sourceTrack != null;
+        })
+        .forEach(managedTrack => {
+          if (managedTrack.selectableTrack) {
+            managedTrack.selectableTrack = null;
+          }
+          if (
+            selectedTrack &&
+            managedTrack.shakaTrack &&
+            managedTrack.shakaTrack.active &&
+            isShakaTrackEqual(selectedTrack, managedTrack.shakaTrack)
+          ) {
+            shakaPlayer.setTextTrackVisibility(false);
+          }
+          managedTrack.isBlacklisted = true;
+        });
+    }
   }
 
   function handleSourcePropChange(props: { source?: ?PlaybackSource, textTracks?: ?Array<SourceTrack> }) {


### PR DESCRIPTION
## *What* does this PR do?

Adds a try/catch around the call to `shakaPlayer.isTextTrackVisible` within `blacklistExistingSideLoadedTracks`

## *Why* are you suggesting this change?

I have observed errors coming from shaka-player `isTextVisible` that trace to `blacklistExistingSideLoadedTracks` in the call stack. This can happen due to early cleanup. We need to add error handling, similarly to what is currently happening in the `update` function in `shakaTextTrackManager.js`.