### PR TITLE
feat: Enhance manual bitrate switching strategy with options (instant and smooth) within fix-bitrate selection strategy

### DIFF
--- a/src/replay/components/player/VideoStreamer/HlsjsVideoStreamer/hlsjsBitrateManager.js
+++ b/src/replay/components/player/VideoStreamer/HlsjsVideoStreamer/hlsjsBitrateManager.js
@@ -18,7 +18,7 @@ function getBitrateAsKbps(level: HlsjsQualityLevel) {
   return (level && Math.ceil(level.bitrate / 1000)) || 0;
 }
 
-function manualbitrateSwitch(hls, configuration, switchTrackId) {
+function manualBitrateSwitch(hls, configuration, switchTrackId) {
   const { manualBitrateSwitchStrategy } = configuration || {};
   if (manualBitrateSwitchStrategy === "instant-switch") {
     hls.currentLevel = switchTrackId;
@@ -120,19 +120,19 @@ const getHlsjsBitrateManager = <P: PropsWithInitial>(
       const { configuration } = streamer.props;
       if (bitrate === 'min') {
         if (Array.isArray(hls.levels) && hls.levels.length > 0) {
-          manualbitrateSwitch(hls, configuration, 0);
+          manualBitrateSwitch(hls, configuration, 0);
           updateStreamState({ bitrateFix: getBitrateAsKbps(hls.levels[0]) });
           log && log('Fixing bitrate to lowest level out of ' + hls.levels.length);
         }
       } else if (bitrate === 'max') {
         if (Array.isArray(hls.levels) && hls.levels.length > 0) {
-          manualbitrateSwitch(hls, configuration, hls.levels.length - 1);
+          manualBitrateSwitch(hls, configuration, hls.levels.length - 1);
           updateStreamState({ bitrateFix: getBitrateAsKbps(hls.levels[hls.levels.length - 1]) });
           log && log('Fixing bitrate to highest level out of ' + hls.levels.length);
         }
       } else if (bitrate == null || bitrate === Infinity || isNaN(bitrate) || bitrate < 0 || !bitrate) {
         log && log('Resetting fixing of bitrate.');
-        manualbitrateSwitch(hls, configuration, -1);
+        manualBitrateSwitch(hls, configuration, -1);
         updateStreamState({ bitrateFix: null });
       } else if (typeof bitrate === 'string') {
         log &&
@@ -144,7 +144,7 @@ const getHlsjsBitrateManager = <P: PropsWithInitial>(
         if (Array.isArray(hls.levels)) {
           for (var i = 0; i < hls.levels.length; i++) {
             if (getBitrateAsKbps(hls.levels[i]) === bitrate) {
-              manualbitrateSwitch(hls, configuration, i);
+              manualBitrateSwitch(hls, configuration, i);
               log && log('Fixing bitrate to HLS level ' + i, hls.levels);
               updateStreamState({ bitrateFix: bitrate });
               return;

--- a/src/replay/components/player/VideoStreamer/ShakaVideoStreamer/shakaBitrateManager.js
+++ b/src/replay/components/player/VideoStreamer/ShakaVideoStreamer/shakaBitrateManager.js
@@ -8,7 +8,8 @@ declare class Object {
 }
 
 type PropsWithInitial = {
-  initialPlaybackProps?: InitialPlaybackProps
+  initialPlaybackProps?: InitialPlaybackProps,
+  configuration?: any
 };
 
 function getBitrateAsBps(track) {
@@ -33,6 +34,16 @@ function isActiveTrack(track: ShakaTrack) {
 
 function isUnique(item, index, arr) {
   return arr.indexOf(item) === index;
+}
+
+function manualbitrateSwitch(shakaPlayer: ShakaPlayer, configuration, track: ShakaTrack) {
+  const { manualBitrateSwitchStrategy } = configuration || {};
+  shakaPlayer.configure({ abr: { enabled: false, restrictions: { maxBandwidth: Infinity } } });
+  if (manualBitrateSwitchStrategy === "instant-switch") {
+    shakaPlayer.selectVariantTrack(track, true);
+  } else {
+    shakaPlayer.selectVariantTrack(track);
+  }
 }
 
 const resetConfiguration = { abr: { enabled: true, restrictions: { maxBandwidth: Infinity } } };
@@ -103,6 +114,7 @@ const getShakaBitrateManager = <P: PropsWithInitial>(
   }
 
   function fixBitrate(bitrate: ?(number | 'max' | 'min')) {
+    const { configuration } = streamer.props;
     if (typeof bitrate === 'string') {
       try {
         const sortedTracks = shakaPlayer
@@ -112,8 +124,7 @@ const getShakaBitrateManager = <P: PropsWithInitial>(
         const desiredVariantTrack =
           bitrate === 'min' ? sortedTracks[0] : bitrate === 'max' ? sortedTracks[sortedTracks.length - 1] : null;
         if (desiredVariantTrack) {
-          shakaPlayer.configure({ abr: { enabled: false, restrictions: { maxBandwidth: Infinity } } });
-          shakaPlayer.selectVariantTrack(desiredVariantTrack);
+          manualbitrateSwitch(shakaPlayer, configuration, desiredVariantTrack);
           updateStreamState({ bitrateFix: getBitrateAsKbps(desiredVariantTrack) });
         } else {
           shakaPlayer.configure(resetConfiguration);
@@ -133,7 +144,7 @@ const getShakaBitrateManager = <P: PropsWithInitial>(
             shakaPlayer.getVariantTracks()
           );
       }
-    } else if (isNaN(bitrate) || bitrate == null || bitrate < 0 || !bitrate) {
+    } else if (isNaN(bitrate) || bitrate === Infinity || bitrate == null || bitrate < 0 || !bitrate) {
       shakaPlayer.configure(resetConfiguration);
       updateStreamState({ bitrateFix: null });
       log && log('Resetting bitrate locking.');
@@ -142,8 +153,7 @@ const getShakaBitrateManager = <P: PropsWithInitial>(
         return getBitrateAsKbps(track) === bitrate;
       })[0];
       if (matchingTrack) {
-        shakaPlayer.configure({ abr: { enabled: false, restrictions: { maxBandwidth: Infinity } } });
-        shakaPlayer.selectVariantTrack(matchingTrack);
+        manualbitrateSwitch(shakaPlayer, configuration, matchingTrack);
         updateStreamState({ bitrateFix: getBitrateAsKbps(matchingTrack) });
         log && log('Locking at bitrate ' + bitrate + '.', matchingTrack);
       } else {
@@ -164,7 +174,8 @@ const getShakaBitrateManager = <P: PropsWithInitial>(
     },
     streaming: updateBitrateProps,
     adaptation: updateBitrateProps,
-    trackschanged: updateBitrateProps
+    trackschanged: updateBitrateProps,
+    variantchanged: updateBitrateProps
   };
 
   Object.entries(shakaEventHandlers).forEach(([name, handler]) => {

--- a/src/replay/components/player/VideoStreamer/ShakaVideoStreamer/shakaBitrateManager.js
+++ b/src/replay/components/player/VideoStreamer/ShakaVideoStreamer/shakaBitrateManager.js
@@ -36,7 +36,7 @@ function isUnique(item, index, arr) {
   return arr.indexOf(item) === index;
 }
 
-function manualbitrateSwitch(shakaPlayer: ShakaPlayer, configuration, track: ShakaTrack) {
+function manualBitrateSwitch(shakaPlayer: ShakaPlayer, configuration, track: ShakaTrack) {
   const { manualBitrateSwitchStrategy } = configuration || {};
   shakaPlayer.configure({ abr: { enabled: false, restrictions: { maxBandwidth: Infinity } } });
   if (manualBitrateSwitchStrategy === "instant-switch") {
@@ -124,7 +124,7 @@ const getShakaBitrateManager = <P: PropsWithInitial>(
         const desiredVariantTrack =
           bitrate === 'min' ? sortedTracks[0] : bitrate === 'max' ? sortedTracks[sortedTracks.length - 1] : null;
         if (desiredVariantTrack) {
-          manualbitrateSwitch(shakaPlayer, configuration, desiredVariantTrack);
+          manualBitrateSwitch(shakaPlayer, configuration, desiredVariantTrack);
           updateStreamState({ bitrateFix: getBitrateAsKbps(desiredVariantTrack) });
         } else {
           shakaPlayer.configure(resetConfiguration);
@@ -153,7 +153,7 @@ const getShakaBitrateManager = <P: PropsWithInitial>(
         return getBitrateAsKbps(track) === bitrate;
       })[0];
       if (matchingTrack) {
-        manualbitrateSwitch(shakaPlayer, configuration, matchingTrack);
+        manualBitrateSwitch(shakaPlayer, configuration, matchingTrack);
         updateStreamState({ bitrateFix: getBitrateAsKbps(matchingTrack) });
         log && log('Locking at bitrate ' + bitrate + '.', matchingTrack);
       } else {

--- a/src/replay/components/player/VideoStreamer/types.js
+++ b/src/replay/components/player/VideoStreamer/types.js
@@ -154,6 +154,8 @@ export type VideoStreamerProps = CommonProps & {
   onPlaybackError?: PlaybackError => void
 };
 
+export type ManualBitrateSwitchStrategy = 'smooth-switch' | 'instant-switch';
+
 export type VideoStreamerConfiguration = {
   licenseAcquisition?: ?{
     widevine: {
@@ -183,6 +185,7 @@ export type VideoStreamerConfiguration = {
     withCredentials?: ?boolean
   },
   logLevel?: 'NONE' | 'ERROR' | 'WARNING' | 'INFO' | 'DEBUG' | 'VERBOSE',
+  manualBitrateSwitchStrategy?: ?ManualBitrateSwitchStrategy,
   defaultBandwidth?: ?number,
   crossOrigin?: ?string,
   playsInline?: ?boolean,

--- a/src/replay/components/player/VideoStreamer/types.js
+++ b/src/replay/components/player/VideoStreamer/types.js
@@ -185,7 +185,7 @@ export type VideoStreamerConfiguration = {
     withCredentials?: ?boolean
   },
   logLevel?: 'NONE' | 'ERROR' | 'WARNING' | 'INFO' | 'DEBUG' | 'VERBOSE',
-  manualBitrateSwitchStrategy?: ?ManualBitrateSwitchStrategy,
+  manualBitrateSwitchStrategy?: ManualBitrateSwitchStrategy,
   defaultBandwidth?: ?number,
   crossOrigin?: ?string,
   playsInline?: ?boolean,

--- a/src/replay/default-player/baseConfiguration.js
+++ b/src/replay/default-player/baseConfiguration.js
@@ -4,7 +4,8 @@ import type { PlayerConfiguration } from './types';
 
 export const baseConfiguration: PlayerConfiguration = {
   videoStreamer: {
-    logLevel: 'WARNING'
+    logLevel: 'WARNING',
+    manualBitrateSwitchStrategy: 'smooth-switch'
   },
   interactionDetector: {
     inactivityDelay: 2

--- a/src/replay/docs/advanced-playback/bitrates.mdx
+++ b/src/replay/docs/advanced-playback/bitrates.mdx
@@ -43,8 +43,7 @@ to the currently streaming bitrate.
 From the available bitrates in `QualitySelection` options in Replay, When a specific bitrate is selected then it will indicate a maximum bitrate to be considered for adaptive
 bitrate switching.
 
-The following example contains `QualitySelection` options in Replay and hovering over the options there will be available bitrates of the stream and an indicator will point
-to the current streaming bitrate. Then a specific bitrate can be selected and Replay will consider it the maximum bitrate for adaptive switching.
+The following example contains `QualitySelection` options in Replay and from this option when a specific bitrate is selected, Replay will consider it as the maximum bitrate for adaptive switching.
 
 <Playground>
   <Replay
@@ -65,7 +64,7 @@ While the manual quality selection strategy(`fix-bitrate`) is enabled with `smoo
 When selecting a specific bitrate among different bitrates, the switching won't happen right away. After the already buffered streaming segment of the previously selected bitrate
 is played out, the switching will happen. By default, `smooth-switch` strategy is enabled in Replay with manual quality selection (`fix-bitrate`).
 
-The following example contains both override base configuration of Repaly for enabling manual smooth quality selection and ways to pass that overridden configuration.
+The following example contains both override base configuration of Replay for enabling manual smooth quality selection and ways to pass that overridden configuration.
 
 <Playground>
   <Replay
@@ -89,7 +88,7 @@ While the manual bitrate selection strategy(`fix-bitrate`) is enabled with `inst
 At the time of selecting a specific bitrate among different bitrates, The bitrate will be selected right away. For enabling `smooth-switch` strategy of `fix-bitrate` in Replay,
 user has to override base configuration.
 
-The following example contains both override base configuration of Repaly for enabling manual instant quality selection and ways to pass that overridden configuration.
+The following example contains both override base configuration of Replay for enabling manual instant quality selection and ways to pass that overridden configuration.
 
 <Playground>
   <Replay

--- a/src/replay/docs/advanced-playback/bitrates.mdx
+++ b/src/replay/docs/advanced-playback/bitrates.mdx
@@ -61,8 +61,8 @@ to the current streaming bitrate. Then a specific bitrate can be selected and Re
 
 ### Smooth switch
 
-While the manual quality selection strategy(`fix-bitrate`) is enabled with `smooth-switch` strategy in Replay, user can select among different available bitrates of streams.
-When selecting a specific bitrate among different bitrates, The switching won't be at the right away. After already buffered streaming segment of previously selected bitrate
+While the manual quality selection strategy(`fix-bitrate`) is enabled with `smooth-switch` strategy in Replay, the user can select among different available bitrates of streams.
+When selecting a specific bitrate among different bitrates, the switching won't happen right away. After the already buffered streaming segment of the previously selected bitrate
 is played out, the switching will happen. By default, `smooth-switch` strategy is enabled in Replay with manual quality selection (`fix-bitrate`).
 
 The following example contains both override base configuration of Repaly for enabling manual smooth quality selection and ways to pass that overridden configuration.

--- a/src/replay/docs/advanced-playback/bitrates.mdx
+++ b/src/replay/docs/advanced-playback/bitrates.mdx
@@ -40,21 +40,8 @@ to the currently streaming bitrate.
 
 ### Capped selection
 
-From the available bitrates in `QualitySelection` options in Replay, When a specific bitrate is selected then it will indicate a maximum bitrate to be considered for adaptive
-bitrate switching.
-
-The following example contains `QualitySelection` options in Replay and from this option when a specific bitrate is selected, Replay will consider it as the maximum bitrate for adaptive switching.
-
-<Playground>
-  <Replay
-    source={{
-             streamUrl: 'public/example-media/adaptive.m3u8',
-             contentType: 'application/x-mpegurl'
-           }}
-    initialPlaybackProps={{ isPaused: true }}>
-    <CompoundVideoStreamer/>
-  </Replay>
-</Playground>
+When a specific bitrate is selected from the options mentioned above, it will indicate a maximum bitrate to be considered for adaptive bitrate switching. Replay will consider it as
+the maximum bitrate for adaptive switching.
 
 ## Manual quality selection
 

--- a/src/replay/docs/advanced-playback/bitrates.mdx
+++ b/src/replay/docs/advanced-playback/bitrates.mdx
@@ -4,6 +4,108 @@ route: /advanced-playback/bitrates
 menu: 'Advanced playback'
 ---
 
+import { Playground, PropsTable } from 'docz';
+import Replay from '../../default-player/Replay';
+import HlsjsVideoStreamer from '../../components/player/VideoStreamer/HlsjsVideoStreamer/HlsjsVideoStreamer';
+import ShakaVideoStreamer from '../../components/player/VideoStreamer/ShakaVideoStreamer/ShakaVideoStreamer';
+import CompoundVideoStreamer from '../../components/player/VideoStreamer/CompoundVideoStreamer/CompoundVideoStreamer';
+import '../../replay-default.css';
+
 # Bitrates and adaptive quality selection
 
-This chapter is not written yet, but will discuss how an underlying adaptive streaming library's quality management is exposed in Replay.
+Bitrates and adaptive quality selection in Replay is supported through third party player integrations, namely several different `<...VideoStreamer/>` components included in the Replay package. Two of these integrate the most common and mature open source alternatives,
+HLS.js and Shaka Player. Both adaptive quality selection and manual quality selection options are available in Replay. Also, there are some options to control bitrates selection both in adaptive quality selection and manual quality selection.
+
+Examples of the different bitrates and adaptive quality selection use case might be for both HLS and DASH streams.
+
+## Adaptive quality selection
+
+### Automatic selection
+
+By default, Replay handles quality switch automatically, using heuristics based on fragment loading bitrate and quality level bandwidth exposed in the variant manifest.
+
+The following example contains `QualitySelection` options in Replay and hovering over the options there will be available bitrates of the stream and an indicator will point
+to the currently streaming bitrate. 
+
+<Playground>
+  <Replay
+    source={{
+             streamUrl: 'public/example-media/adaptive.m3u8',
+             contentType: 'application/x-mpegurl'
+           }}
+    initialPlaybackProps={{ isPaused: true }}>
+    <CompoundVideoStreamer/>
+  </Replay>
+</Playground>
+
+### Capped selection
+
+From the available bitrates in `QualitySelection` options in Replay, When a specific bitrate is selected then it will indicate a maximum bitrate to be considered for adaptive
+bitrate switching.
+
+The following example contains `QualitySelection` options in Replay and hovering over the options there will be available bitrates of the stream and an indicator will point
+to the current streaming bitrate. Then a specific bitrate can be selected and Replay will consider it the maximum bitrate for adaptive switching.
+
+<Playground>
+  <Replay
+    source={{
+             streamUrl: 'public/example-media/adaptive.m3u8',
+             contentType: 'application/x-mpegurl'
+           }}
+    initialPlaybackProps={{ isPaused: true }}>
+    <CompoundVideoStreamer/>
+  </Replay>
+</Playground>
+
+## Manual quality selection
+
+### Smooth switch
+
+While the manual quality selection strategy(`fix-bitrate`) is enabled with `smooth-switch` strategy in Replay, user can select among different available bitrates of streams.
+When selecting a specific bitrate among different bitrates, The switching won't be at the right away. After already buffered streaming segment of previously selected bitrate
+is played out, the switching will happen. By default, `smooth-switch` strategy is enabled in Replay with manual quality selection (`fix-bitrate`).
+
+The following example contains both override base configuration of Repaly for enabling manual smooth quality selection and ways to pass that overridden configuration.
+
+<Playground>
+  <Replay
+    source={{
+             streamUrl: 'public/example-media/adaptive.m3u8',
+             contentType: 'application/x-mpegurl'
+           }}
+    options={{
+      controls: {
+        qualitySelectionStrategy: 'fix-bitrate'
+      },
+    }}
+    initialPlaybackProps={{ isPaused: true }}>
+    <CompoundVideoStreamer/>
+  </Replay>
+</Playground>
+
+### Instant switch
+
+While the manual bitrate selection strategy(`fix-bitrate`) is enabled with `instant-switch` strategy in Replay, user can select among different available bitrates of streams.
+At the time of selecting a specific bitrate among different bitrates, The bitrate will be selected right away. For enabling `smooth-switch` strategy of `fix-bitrate` in Replay,
+user has to override base configuration.
+
+The following example contains both override base configuration of Repaly for enabling manual instant quality selection and ways to pass that overridden configuration.
+
+<Playground>
+  <Replay
+    source={{
+             streamUrl: 'public/example-media/adaptive.m3u8',
+             contentType: 'application/x-mpegurl'
+           }}
+    options={{
+      videoStreamer: {
+        manualBitrateSwitchStrategy: 'instant-switch'
+      },
+      controls: {
+        qualitySelectionStrategy: 'fix-bitrate'
+      },
+    }}
+    initialPlaybackProps={{ isPaused: true }}>
+    <CompoundVideoStreamer/>
+  </Replay>
+</Playground>


### PR DESCRIPTION
## *What* does this PR do?

This PR adds two different manual bitrate selection strategies:
1. `smooth-switch`: While manual bitrate selection strategy(`fix-bitrate`) is enabled with `smooth-switch` strategy in replay player, user can select among different available bitrates of streams. At the time of selecting one bitrate among different bitrates, The switching won't be at the right away. After already buffered streaming segment of previous selected bitrate is played out, then the switching will happen. By default, `smooth-switch` strategy of `fix-bitrate` is enabled in `replay` player.
2. `instant-switch`: While manual bitrate selection strategy(`fix-bitrate`) is enabled with `instant-switch` strategy in replay player, user can select among different available bitrates of streams. At the time of selecting one bitrate among different bitrates, The bitrate will be selected at the right away. For enabling `smooth-switch` strategy of `fix-bitrate` in `replay` player, user have to override base configuration of player.

This PR also fixes a small bug of hls video streamer component. The error was basically like, when user switch from adaptive bitrate selection to manual one and then move back to adaptive selection strategy, the selection wasn't happening in replay player. Now the issue is resolved.

## *Why* are you suggesting this change?

Because earlier, User can't switch to a desired bitrate at the right away. That was causing low quality of video at the start of the streaming in the replay player.

## *Who* is the change affecting?

Manual bitrate selection strategy(`fix-bitrate`).

## *What* is affected by this change?

Manual bitrate selection strategy(`fix-bitrate`) of `shakaBitrateManager` and `hlsjsBitrateManager` components of `replay`.
 
## UI Changes :paintbrush:

Nothing.

## API Changes 

Nothing.

## Dependencies

No dependency.

## Automated Testing

Unit tests are added to verify the functionality of both **smooth** and **instant** manual bitrate selection strategy of both shaka video streamer and hls video streamer.

## Manual Testing

Manual testing will be done later by [vimond](https://www.vimond.com/) after publishing a new version of package.
